### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an error message

### DIFF
--- a/src/main/java/com/fintech/core/payments/controller/TransactionController.java
+++ b/src/main/java/com/fintech/core/payments/controller/TransactionController.java
@@ -118,7 +118,7 @@ public class TransactionController {
             return ResponseEntity.ok("Import completed successfully");
         } catch (Exception e) {
             logger.severe("XML import failed: " + e.getMessage());
-            return ResponseEntity.badRequest().body("Import failed: " + e.getMessage());
+            return ResponseEntity.badRequest().body("Import failed");
         }
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/Fortrex26/demo-clase-5-yi/security/code-scanning/1](https://github.com/Fortrex26/demo-clase-5-yi/security/code-scanning/1)

To fix this issue, the code within the `importTransactions` endpoint should be changed so that it does NOT include `e.getMessage()` in the response body sent to the user. Instead, the exception details should be logged on the server using the logger, while a generic error message such as `"Import failed"` or `"Failed to import transactions"` should be returned to the API client. Only the non-revealing/generic error should be present in the client response. The logger call (already present on line 120) should remain so that server-side logs preserve the actual exception details for later diagnosis or review.

Specifically, in file `src/main/java/com/fintech/core/payments/controller/TransactionController.java`, inside the `importTransactions` method, amend the line:
```java
return ResponseEntity.badRequest().body("Import failed: " + e.getMessage());
```
to:
```java
return ResponseEntity.badRequest().body("Import failed");
```
No additional imports or helper methods are necessary beyond the existing logger usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
