### PR TITLE
Potential fix for code scanning alert no. 5: Cross-site scripting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,12 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+	    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.14.0</version>
+    </dependency>
+</dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/fintech/core/payments/controller/UserController.java
+++ b/src/main/java/com/fintech/core/payments/controller/UserController.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.apache.commons.text.StringEscapeUtils;
 
 @RestController
 @RequestMapping("/api/users")
@@ -134,7 +135,8 @@ public class UserController {
     @GetMapping("/validate")
     public ResponseEntity<String> validateUser(@RequestParam String input) {
         String result = userService.validateUserData(input);
-        return ResponseEntity.ok("Validation result: " + result);
+        String safeResult = result == null ? "" : StringEscapeUtils.escapeHtml4(result);
+        return ResponseEntity.ok("Validation result: " + safeResult);
     }
     
     @GetMapping("/debug/{userId}")


### PR DESCRIPTION
Potential fix for [https://github.com/Fortrex26/demo-clase-5-yi/security/code-scanning/5](https://github.com/Fortrex26/demo-clase-5-yi/security/code-scanning/5)

The best way to fix this issue is to carefully encode (escape) the output containing user-supplied data before returning it in the HTTP response, especially for text that may be interpreted by browsers. Given the structure (value returned in the response body), you should apply proper HTML escaping to the user-supplied data before concatenating it into the response string. Using Apache Commons Text's `StringEscapeUtils.escapeHtml4()` is the standard way in Java/Spring. 

You need to:
- Add an import for `org.apache.commons.text.StringEscapeUtils` in the controller.
- In the `validateUser` method, escape the `result` before concatenating it into the output string (`ResponseEntity.ok("Validation result: " + result)`).

Only edit the controller file as the service does not handle rendering. This is sufficient to address the XSS risk while preserving current functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
